### PR TITLE
fix a small bug and make it more confortable

### DIFF
--- a/lib/python-debugger.js
+++ b/lib/python-debugger.js
@@ -17,7 +17,7 @@ module.exports = {
     })(this));
   },
   insert: function() {
-    var IMPORT_STATEMENT, cursor, cursors, editor, i, index, insert_position, j, len, len1, line, options, results, saved_positions;
+    var IMPORT_STATEMENT, cursor, cursors, editor, i, index, insert_position, j, len, len1, line, options, results, saved_positions, former_level;
     IMPORT_STATEMENT = "import ipdb\n";
     editor = atom.workspace.getActivePaneItem();
     cursors = editor.getCursors();
@@ -26,11 +26,13 @@ module.exports = {
       cursor = cursors[i];
       cursor.moveToFirstCharacterOfLine();
       saved_positions.push(cursor.getBufferPosition());
-    }
+    };
+    former_level = editor.indentationForBufferRow(cursor.getScreenRow());
     editor.insertText("ipdb.set_trace()  ######### Break Point ###########\n", options = {
       "autoIndentNewline": true,
       "autoIndent": true
     });
+    editor.setIndentationForBufferRow(cursor.getScreenRow(), former_level)
     editor.moveToTop();
     insert_position = editor.getCursorBufferPosition();
     editor.moveToBeginningOfLine();


### PR DESCRIPTION
now it can be used more comfortable wherever cursor at (at the latest version, insert function would break next line's indention when cursor is not at the start of the line). and also fixed a small bug https://github.com/fxdgear/atom-python-debugger/issues/20.
